### PR TITLE
fix minor typo in nvme_complete_rq

### DIFF
--- a/originals/Ch09_Disks/nvmelatency.bt
+++ b/originals/Ch09_Disks/nvmelatency.bt
@@ -53,7 +53,7 @@ kprobe:nvme_complete_rq
 	$opcode = $cmd->common.opcode & 0xff;
 	@usecs[$disk->disk_name, @ioopcode[$opcode]] =
 	    hist((nsecs - @start[arg0]) / 1000);
-	delete(@start[tid]); delete(@cmd[tid]);
+	delete(@start[arg0]); delete(@cmd[arg0]);
 }
 
 END


### PR DESCRIPTION
Upon completion, delete entries from start and cmd map for req (arg0) key instead of tid key

Signed-off-by: Venkat Ramesh <venkatraghavan@fb.com>