### PR TITLE
shellsnoop: Update to Python3 (fix output)

### DIFF
--- a/originals/Ch11_Security/shellsnoop.py
+++ b/originals/Ch11_Security/shellsnoop.py
@@ -154,7 +154,7 @@ def print_event(cpu, data, size):
         print("echo -e '%s\\c'" % printable)
         last_ts = event.ts
     else:
-        print("%s" % event.buf[0:event.count], end="")
+        print("%s" % event.buf[0:event.count].decode(), end="")
     sys.stdout.flush()
 
 # loop with callback to print_event


### PR DESCRIPTION
Hello Brendan,

An incredible book!

This fixes the output of this shellsnoop.py to work with Python3:
- It fixes printing `b'char'` to `char` for each stdin char on stdin of the traced processes.

PS, just as a Question:
Is it possible for you license these examples under e.g. the upstream Apache 2.0 License so they could be merged upstream?

Thanks!